### PR TITLE
Added "presentation mode" support for XFCE-PM

### DIFF
--- a/caffeine/core.py
+++ b/caffeine/core.py
@@ -28,7 +28,7 @@ from . import utils
 from .icons import empty_cup_icon, full_cup_icon
 from .inhibitors import DpmsInhibitor, GnomeInhibitor, XautolockInhibitor, \
     XdgPowerManagmentInhibitor, XdgScreenSaverInhibitor, XorgInhibitor, \
-    XssInhibitor
+    XssInhibitor, xfceInhibitor
 
 # from pympler import tracker
 # tr = tracker.SummaryTracker()
@@ -52,7 +52,8 @@ class Caffeine(GObject.GObject):
             XssInhibitor(),
             DpmsInhibitor(),
             XorgInhibitor(),
-            XautolockInhibitor()
+            XautolockInhibitor(),
+            xfceInhibitor()
         ]
 
         self.__process_manager = process_manager

--- a/caffeine/inhibitors.py
+++ b/caffeine/inhibitors.py
@@ -228,3 +228,24 @@ class XautolockInhibitor(BaseInhibitor):
     @property
     def applicable(self):
         return os.system("pgrep xautolock") is 0
+    
+class xfceInhibitor(BaseInhibitor):
+
+    def __init__(self):
+        BaseInhibitor.__init__(self)
+
+    def inhibit(self):
+        self.running = True
+
+        os.system("xfconf-query -c xfce4-power-manager -p /xfce4-power-manager/presentation-mode -s true")
+
+    def uninhibit(self):
+        self.running = False
+
+        
+        os.system("xfconf-query -c xfce4-power-manager -p /xfce4-power-manager/presentation-mode -s false")
+
+    @property
+    def applicable(self):
+        # TODO!
+        return True


### PR DESCRIPTION
in xfce4-power-manager screen dimming is active even when PM is disabled but it has an allmighty mode called "presentation mode" to prevent dimming and every other PM.
added cli methods