### PR TITLE
Add option to enable caffeine-ng on startup

### DIFF
--- a/caffeine/main.py
+++ b/caffeine/main.py
@@ -173,6 +173,7 @@ class GUI:
 
         show_tray_icon = settings.get_boolean("show-tray-icon")
         show_notification = settings.get_boolean("show-notification")
+        activate_on_startup = settings.get_boolean("activate-on-startup")
 
         if appindicator_avail:
             self.AppInd = \
@@ -246,16 +247,21 @@ class GUI:
 
         self.trayicon_cb = get("trayicon_cbutton")
         self.notification_cb = get("notification_cbutton")
+        self.autoactivation_cb = get("autoactivation_cbutton")
 
         self.notification_cb.set_sensitive(not show_tray_icon)
 
         settings.connect("changed::show-tray-icon", self.on_trayicon_changed)
         settings.connect("changed::show-notification",
                          self.on_notification_changed)
+        settings.connect("changed::activate-on-startup",
+                         self.on_autoactivation_changed)
 
         settings.bind("show-tray-icon", self.trayicon_cb, "active",
                       Gio.SettingsBindFlags.DEFAULT)
         settings.bind("show-notification", self.notification_cb, "active",
+                      Gio.SettingsBindFlags.DEFAULT)
+        settings.bind("activate-on-startup", self.autoactivation_cb, "active",
                       Gio.SettingsBindFlags.DEFAULT)
 
         # about dialog
@@ -275,6 +281,10 @@ class GUI:
             self.status_icon.connect("popup-menu", self.on_R_click)
 
         builder.connect_signals(self)
+
+        if activate_on_startup:
+            logger.info("Activate on startup enabled. Inhibiting.")
+            self.setActive(True)
 
     def setActive(self, active):
         self.__core.set_activated(active)
@@ -356,6 +366,9 @@ class GUI:
 
     # Startup Notifications
     def on_notification_changed(self, settings, key, data=None):
+        pass
+
+    def on_autoactivation_changed(self, settings, key, data=None):
         pass
 
     # Menu callbacks

--- a/share/caffeine/glade/GUI.glade
+++ b/share/caffeine/glade/GUI.glade
@@ -472,7 +472,30 @@ Vagner K. Dos Santos
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">2</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment" id="alignment3">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="left_padding">10</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="autoactivation_cbutton">
+                                    <property name="label" translatable="yes">Activate on startup</property>
+                                    <property name="use_action_appearance">False</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="xalign">0</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
@@ -630,7 +653,7 @@ prevent the screensaver and powersaving modes on their own.</property>
                               <packing>
                                 <property name="expand">True</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
@@ -646,7 +669,7 @@ prevent the screensaver and powersaving modes on their own.</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>
@@ -669,7 +692,7 @@ prevent the screensaver and powersaving modes on their own.</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">5</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                             <child>
@@ -693,7 +716,7 @@ prevent the screensaver and powersaving modes on their own.</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">6</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                           </object>

--- a/share/glib-2.0/schemas/net.launchpad.caffeine.gschema.xml
+++ b/share/glib-2.0/schemas/net.launchpad.caffeine.gschema.xml
@@ -15,6 +15,11 @@
             <summary></summary>
             <description></description>
         </key>
+        <key type="b" name="activate-on-startup">
+            <default>false</default>
+            <summary></summary>
+            <description></description>
+        </key>
 
     </schema>
 </schemalist>


### PR DESCRIPTION
Adds a checkbox to the preference window where the caffeine can be set to be activated automatically on startup. This option is set to False by default. 

Creates the required bindings in the GUI class.

Adds a check to GUI.init to enable caffeine if the option is enabled.

---

Suggestions are welcome.