### PR TITLE
Add support for xidlehook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ System requirements
 
 * Either a screensaver that implements the ``org.freedesktop.ScreenSaver``
   API (this includes KDE, amongst others) API, gnome-screensaver, XSS and/or
-  DPMS, xautolock.
+  DPMS, xautolock, xidlehook.
 * Python 3 (apparently works with Python 2, but not officially supported).
 
 See ``requirements.txt`` for required python packages

--- a/caffeine/core.py
+++ b/caffeine/core.py
@@ -30,7 +30,7 @@ from . import utils
 from .icons import empty_cup_icon, full_cup_icon
 from .inhibitors import DpmsInhibitor, GnomeInhibitor, XautolockInhibitor, \
     XdgPowerManagmentInhibitor, XdgScreenSaverInhibitor, XorgInhibitor, \
-    XssInhibitor
+    XssInhibitor, XidlehookInhibitor
 
 # from pympler import tracker
 # tr = tracker.SummaryTracker()
@@ -53,6 +53,7 @@ class Caffeine(GObject.GObject):
             XssInhibitor(),
             XorgInhibitor(),
             XautolockInhibitor(),
+            XidlehookInhibitor(),
             XdgScreenSaverInhibitor(),
             DpmsInhibitor()
         ]

--- a/caffeine/inhibitors.py
+++ b/caffeine/inhibitors.py
@@ -247,3 +247,23 @@ class XautolockInhibitor(BaseInhibitor):
     @property
     def applicable(self):
         return os.system("pgrep xautolock") == 0
+
+
+class XidlehookInhibitor(BaseInhibitor):
+
+    def __init__(self):
+        BaseInhibitor.__init__(self)
+
+    def inhibit(self):
+        self.running = True
+
+        os.system("pkill -SIGSTOP xidlehook")
+
+    def uninhibit(self):
+        self.running = False
+
+        os.system("pkill -SIGCONT xidlehook")
+
+    @property
+    def applicable(self):
+        return os.system("pgrep xidlehook") == 0


### PR DESCRIPTION
It is common for users of window managers to select `xidlehook` as their display locker of choice, over `xautolock`. `xidlehook` doesn't include pause/resume functionality in the CLI itself; relying upon signals passed from the outside. This little PR is intended to pause/resume `xidlehook` processes when Caffeine is toggled.

ref: https://github.com/jD91mZM2/xidlehook