### PR TITLE
Use sink's & source's attributes to detect any pulseaudio activity

### DIFF
--- a/caffeine/core.py
+++ b/caffeine/core.py
@@ -159,7 +159,7 @@ class Caffeine(GObject.GObject):
                         else:
                             # Video or other audio source
                             screen_relevant_procs += 1
-                        # Save the application names
+                        # Save the application's process name
                         application_name = application_output.proplist["application.process.binary"]
                         active_applications.append(application_name)
 
@@ -172,8 +172,8 @@ class Caffeine(GObject.GObject):
                         # Treat recordings as video because likely you don't
                         # want to turn the screen of while recording
                         screen_relevant_procs += 1
-                        # Save the application names
-                        application_name  = application_input.proplist["application.process.binary"]
+                        # Save the application's process name
+                        application_name = application_input.proplist["application.process.binary"]
                         active_applications.append(application_name)
 
             if self.music_procs > 0 or screen_relevant_procs > 0:

--- a/caffeine/core.py
+++ b/caffeine/core.py
@@ -138,6 +138,8 @@ class Caffeine(GObject.GObject):
         # Number of all audio streams including videos. We keep the screen on
         # here:
         screen_relevant_procs = 0
+        # Applications currently playing audio.
+        active_applications = []
 
         if not process_running and not fullscreen:
             # Get all audio playback streams
@@ -157,6 +159,9 @@ class Caffeine(GObject.GObject):
                         else:
                             # Video or other audio source
                             screen_relevant_procs += 1
+                        # Save the application names
+                        application_name = application_output.proplist["application.process.binary"]
+                        active_applications.append(application_name)
 
                 # Get all audio recording streams
                 for application_input in pulseaudio.source_output_list():
@@ -167,12 +172,15 @@ class Caffeine(GObject.GObject):
                         # Treat recordings as video because likely you don't
                         # want to turn the screen of while recording
                         screen_relevant_procs += 1
+                        # Save the application names
+                        application_name  = application_input.proplist["application.process.binary"]
+                        active_applications.append(application_name)
 
             if self.music_procs > 0 or screen_relevant_procs > 0:
                 if self.__auto_activated:
-                    logger.debug("Audio playback detected. No change.")
+                    logger.debug(f"Audio playback detected ({', '.join(active_applications)}). No change.")
                 elif not self.get_activated():
-                    logger.info("Audio playback detected. Inhibiting.")
+                    logger.info(f"Audio playback detected ({', '.join(active_applications)}). Inhibiting.")
 
         if (
             process_running

--- a/caffeine/core.py
+++ b/caffeine/core.py
@@ -146,7 +146,8 @@ class Caffeine(GObject.GObject):
             # as they might be videos
             with Pulse() as pulseaudio:
                 for application_output in pulseaudio.sink_input_list():
-                    if (not application_output.mute                                   # application audio is not muted
+                    if (
+                        not application_output.mute                                   # application audio is not muted
                         and not application_output.corked                             # application audio is not paused
                         and not pulseaudio.sink_info(application_output.sink).mute    # system audio is not muted
                     ):
@@ -159,7 +160,8 @@ class Caffeine(GObject.GObject):
 
                 # Get all audio recording streams
                 for application_input in pulseaudio.source_output_list():
-                    if (not application_input.mute                                     # application input is not muted
+                    if (
+                        not application_input.mute                                     # application input is not muted
                         and not pulseaudio.source_info(application_input.source).mute  # system input is not muted
                     ):
                         # Treat recordings as video because likely you don't


### PR DESCRIPTION
As discussed on #37 with @WhyNotHugo, I'm presenting this pull request. It should provide less false-positives than the original implementation.

Regarding the checks for the recording sources I mirrored what we agreed on on application audio. I, although, decided not to check if the recording source is corked because I don't think that's possible (even if `PulseSinkOutputInfo` has the attribute).

I tested recording tests with Discord. If i muted through the app, that isn't detected by pulseaudio. I don't see that as a big of a problem as I cannot imagine a single case scenario where someone would like if the system didn't suspend because he is alone on a discord channel.

On a side note: do you think we should keep record of the application we have detected that is inhibiting the suspension? I feel like it could be helpful to people.