### PR TITLE
Fixed inhibitors constructors

### DIFF
--- a/caffeine/inhibitors.py
+++ b/caffeine/inhibitors.py
@@ -54,7 +54,7 @@ class BaseInhibitor:
 
 class GnomeInhibitor(BaseInhibitor):
     def __init__(self):
-        super().__init__(self)
+        super().__init__()
         self.bus = dbus.SessionBus()
 
         self.__proxy = None
@@ -86,7 +86,7 @@ class GnomeInhibitor(BaseInhibitor):
 
 class XdgScreenSaverInhibitor(BaseInhibitor):
     def __init__(self):
-        super().__init__(self)
+        super().__init__()
         self.bus = dbus.SessionBus()
 
         self.__cookie = None
@@ -117,7 +117,7 @@ class XdgScreenSaverInhibitor(BaseInhibitor):
 
 class XdgPowerManagmentInhibitor(BaseInhibitor):
     def __init__(self):
-        super().__init__(self)
+        super().__init__()
         self.bus = dbus.SessionBus()
 
         self.__cookie = None


### PR DESCRIPTION
There must have been some oversights when committing this: aeea7f73e2522649b164674b0eb56d00042623e0

super calls are done with `super().__init__()` in python3, not `super().__init__(self)`