### PR TITLE
audio blacklist & peak volume filtering (with GUI) 

### DIFF
--- a/caffeine/assets/glade/GUI.glade
+++ b/caffeine/assets/glade/GUI.glade
@@ -416,6 +416,14 @@ Vagner K. Dos Santos
       <column type="gchararray"/>
     </columns>
   </object>
+  <object class="GtkListStore" id="proc_liststore_audio">
+    <columns>
+      <!-- column-name gdkpixbuf -->
+      <column type="GdkPixbuf"/>
+      <!-- column-name gchararray -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkWindow" id="window">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
@@ -634,6 +642,198 @@ prevent the screensaver and powersaving modes on their own.</property>
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkLabel" id="label4_audio">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Audio detection</property>
+                                <property name="xalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment" id="alignment4_audio">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="left_padding">10</property>
+                                <child>
+                                  <object class="GtkVBox" id="vbox4_audio">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">5</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label5_audio">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Caffeine activates automatically when audio playback/recording is detected.</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkHBox" id="hbox2_audio">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label6_audio">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">List of programs that Caffeine ignores when detecting audio activity:</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkScrolledWindow" id="scrolledwindow1_audio">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="shadow_type">in</property>
+                                        <child>
+                                          <object class="GtkTreeView" id="treeview_audio">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_text" translatable="yes">Audio activity from these processes will not cause Caffeine to activate.</property>
+                                            <property name="model">proc_liststore_audio</property>
+                                            <property name="rules_hint">True</property>
+                                            <child internal-child="selection">
+                                              <object class="GtkTreeSelection" id="treeview-selection1_audio"/>
+                                            </child>
+                                            <child>
+                                              <object class="GtkTreeViewColumn" id="treeviewcolumn1_audio">
+                                                <property name="title">Process Name</property>
+                                                <child>
+                                                  <object class="GtkCellRendererPixbuf" id="cellrendererpixbuf1_audio"/>
+                                                  <attributes>
+                                                    <attribute name="pixbuf">0</attribute>
+                                                  </attributes>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkCellRendererText" id="cellrenderertext1_audio"/>
+                                                  <attributes>
+                                                    <attribute name="text">1</attribute>
+                                                  </attributes>
+                                                </child>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkHButtonBox" id="hbuttonbox2_audio">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="spacing">5</property>
+                                        <property name="layout_style">end</property>
+                                        <child>
+                                          <object class="GtkButton" id="remove_button_audio">
+                                            <property name="label">gtk-remove</property>
+                                            <property name="use_action_appearance">False</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">True</property>
+                                            <property name="use_stock">True</property>
+                                            <signal name="clicked" handler="on_remove_button_audio_clicked" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkButton" id="add_button_audio">
+                                            <property name="label">gtk-add</property>
+                                            <property name="use_action_appearance">False</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">True</property>
+                                            <property name="use_stock">True</property>
+                                            <signal name="clicked" handler="on_add_button_audio_clicked" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkAlignment" id="alignment5_audio_settings">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="left_padding">10</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="audio_peak_filtering_cbutton">
+                                            <property name="label" translatable="yes">Enable audio peak filtering</property>
+                                            <property name="use_action_appearance">False</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkHSeparator" id="hseparator1_audio">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">5</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkLabel" id="label2">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -646,7 +846,7 @@ prevent the screensaver and powersaving modes on their own.</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>
@@ -669,7 +869,7 @@ prevent the screensaver and powersaving modes on their own.</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">5</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                             <child>
@@ -693,7 +893,7 @@ prevent the screensaver and powersaving modes on their own.</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">6</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                           </object>

--- a/caffeine/core.py
+++ b/caffeine/core.py
@@ -153,6 +153,11 @@ class Caffeine(GObject.GObject):
                         and not application_output.corked                             # application audio is not paused
                         and not pulseaudio.sink_info(application_output.sink).mute    # system audio is not muted
                     ):
+                        # ignore silent sinks
+                        sink_source = pulseaudio.sink_info(application_output.sink).monitor_source
+                        sink_peak = pulseaudio.get_peak_sample(sink_source, 0.1)
+                        if not (sink_peak > 0):
+                            continue
                         if application_output.proplist.get("media.role") == "music":
                             # seems to be audio only
                             self.music_procs += 1
@@ -169,6 +174,10 @@ class Caffeine(GObject.GObject):
                         not application_input.mute                                     # application input is not muted
                         and not pulseaudio.source_info(application_input.source).mute  # system input is not muted
                     ):
+                        # ignore silent sources
+                        source_peak = pulseaudio.get_peak_sample(application_input.source, 0.1)
+                        if not (source_peak > 0):
+                            continue
                         # Treat recordings as video because likely you don't
                         # want to turn the screen of while recording
                         screen_relevant_procs += 1

--- a/caffeine/core.py
+++ b/caffeine/core.py
@@ -165,7 +165,7 @@ class Caffeine(GObject.GObject):
                             # Video or other audio source
                             screen_relevant_procs += 1
                         # Save the application's process name
-                        application_name = application_output.proplist["application.process.binary"]
+                        application_name = application_output.proplist.get("application.process.binary", "no name")
                         active_applications.append(application_name)
 
                 # Get all audio recording streams
@@ -182,7 +182,7 @@ class Caffeine(GObject.GObject):
                         # want to turn the screen of while recording
                         screen_relevant_procs += 1
                         # Save the application's process name
-                        application_name = application_input.proplist["application.process.binary"]
+                        application_name = application_input.proplist.get("application.process.binary", "no name")
                         active_applications.append(application_name)
 
             if self.music_procs > 0 or screen_relevant_procs > 0:

--- a/caffeine/main.py
+++ b/caffeine/main.py
@@ -32,7 +32,7 @@ from gi.repository.Notify import Notification  # noqa: E402
 from . import __version__  # noqa: E402
 from .core import Caffeine  # noqa: E402
 from .icons import generic_icon, get_icon_pixbuf  # noqa: E402
-from .paths import get_glade_file, get_whitelist_file, get_whitelist_file_audio  # noqa: E402
+from .paths import get_glade_file, get_whitelist_file, get_blacklist_file_audio  # noqa: E402
 from .procmanager import ProcManager  # noqa: E402
 
 appindicator_avail = True
@@ -130,7 +130,7 @@ class GUI:
     def __init__(self, show_preferences=False, **kwargs):
         # object to manage processes to activate for.
         self.__process_manager = ProcManager(persistence_file=get_whitelist_file())
-        self.__process_manager_audio = ProcManager(persistence_file=get_whitelist_file_audio())
+        self.__process_manager_audio = ProcManager(persistence_file=get_blacklist_file_audio())
 
         self.__core = Caffeine(
             process_manager=self.__process_manager,

--- a/caffeine/paths.py
+++ b/caffeine/paths.py
@@ -39,6 +39,10 @@ def get_whitelist_file():
     return join(__config_dir, "whitelist.txt")
 
 
+def get_whitelist_file_audio():
+    return join(__config_dir, "audio_whitelist.txt")
+
+
 __config_dir = join(xdg_config_home, "caffeine")
 
 
@@ -47,3 +51,6 @@ if not exists(__config_dir):
 
 if not exists(get_whitelist_file()):
     open(get_whitelist_file(), "a").close()
+
+if not exists(get_whitelist_file_audio()):
+    open(get_whitelist_file_audio(), "a").close()

--- a/caffeine/paths.py
+++ b/caffeine/paths.py
@@ -39,8 +39,8 @@ def get_whitelist_file():
     return join(__config_dir, "whitelist.txt")
 
 
-def get_whitelist_file_audio():
-    return join(__config_dir, "audio_whitelist.txt")
+def get_blacklist_file_audio():
+    return join(__config_dir, "audio_blacklist.txt")
 
 
 __config_dir = join(xdg_config_home, "caffeine")
@@ -52,5 +52,5 @@ if not exists(__config_dir):
 if not exists(get_whitelist_file()):
     open(get_whitelist_file(), "a").close()
 
-if not exists(get_whitelist_file_audio()):
-    open(get_whitelist_file_audio(), "a").close()
+if not exists(get_blacklist_file_audio()):
+    open(get_blacklist_file_audio(), "a").close()

--- a/caffeine/procmanager.py
+++ b/caffeine/procmanager.py
@@ -16,16 +16,14 @@
 #
 import os
 
-from .paths import get_whitelist_file
-
 
 class ProcManager:
-    def __init__(self):
-        self.whitelist_file = get_whitelist_file()
+    def __init__(self, persistence_file):
+        self.persistence_file = persistence_file
         self.proc_list = []
 
-        if os.path.exists(self.whitelist_file):
-            self.import_proc(self.whitelist_file)
+        if os.path.exists(self.persistence_file):
+            self.import_proc(self.persistence_file)
 
     def get_process_list(self):
         return self.proc_list[:]
@@ -48,5 +46,5 @@ class ProcManager:
 
     def save(self):
         self.proc_list.sort()
-        with open(self.whitelist_file, "w") as f:
+        with open(self.persistence_file, "w") as f:
             f.write("\n".join(self.proc_list))

--- a/caffeine/triggers.py
+++ b/caffeine/triggers.py
@@ -76,7 +76,11 @@ class FullscreenTrigger:
 class PulseAudioTrigger:
     def __init__(self, process_manager: ProcManager, audio_peak_filtering_active_getter: Callable[[], bool]) -> None:
         self.__process_manager = process_manager
-        self.__audio_peak_filtering_active: bool = property(fget=audio_peak_filtering_active_getter)
+        self.__audio_peak_filtering_active_getter = audio_peak_filtering_active_getter
+
+    @property
+    def __audio_peak_filtering_active(self) -> bool:
+        return self.__audio_peak_filtering_active_getter()
 
     def run(self) -> DesiredState:
         # Let's look for playing audio:

--- a/share/glib-2.0/schemas/net.launchpad.caffeine.gschema.xml
+++ b/share/glib-2.0/schemas/net.launchpad.caffeine.gschema.xml
@@ -15,6 +15,11 @@
             <summary></summary>
             <description></description>
         </key>
+        <key type="b" name="audio-peak-filtering">
+            <default>true</default>
+            <summary></summary>
+            <description></description>
+        </key>
 
     </schema>
 </schemalist>


### PR DESCRIPTION
This adds a blacklist for audio activation and a toggle for ignoring programs whose output/input has 0 peak volume.
I had trouble with false positives such as pulseeffects, scream & wine_loader, where the peak filtering does the job perfectly, but i thought a blacklist would come in handy too.