### PR TITLE
only inhibit/uninhibit if inhibitor not running/running

### DIFF
--- a/caffeine/inhibitors.py
+++ b/caffeine/inhibitors.py
@@ -41,9 +41,11 @@ class BaseInhibitor:
 
     def set(self, state):
         if state:
-            self.inhibit()
+            if not self.running:
+                self.inhibit()
         else:
-            self.uninhibit()
+            if self.running:
+                self.uninhibit()
 
     def is_screen_inhibitor(self):
         return False


### PR DESCRIPTION
I noticed that with versions that have issue #61 where uninhibiting doesn't seem to work, the inhibitor's .uninhibit() was being called frequently. Changing .set() to only call inhibit/uninhibit when necessary seems to have fixed the problem