### PR TITLE
Correct error spelling

### DIFF
--- a/caffeine/cli.py
+++ b/caffeine/cli.py
@@ -99,7 +99,7 @@ def start(
     if kill:
         app.kill()
     elif app.is_running():
-        raise click.ClickException("Caffine is already running.")
+        raise click.ClickException("Caffeine is already running.")
 
     main = GUI(
         show_preferences=preferences,


### PR DESCRIPTION
When starting the application from the terminal and it is already running a error is printed. 
This fix will change  application name to 'Caffeine'  instead of 'Caffine' when printing this error.