### PR TITLE
fix #75: always blacklisting 'peak detect' to fix it on PipeWire

### DIFF
--- a/caffeine/triggers.py
+++ b/caffeine/triggers.py
@@ -116,7 +116,7 @@ class PulseAudioTrigger:
                     if self.__audio_peak_filtering_active:
                         # ignore silent sinks
                         sink_source = pulseaudio.sink_info(application_output.sink).monitor_source
-                        sink_peak = pulseaudio.get_peak_sample(sink_source, 0.1)
+                        sink_peak = pulseaudio.get_peak_sample(sink_source, 0.4)
                         if not sink_peak > 0:
                             continue
                     if application_output.proplist.get("media.role") == "music":
@@ -132,6 +132,7 @@ class PulseAudioTrigger:
             for application_input in pulseaudio.source_output_list():
                 if (
                     not application_input.mute  # application input is not muted
+                    and application_input.name != "peak detect" # source_output_list() returns the object used to peak for audio playback streams
                     and not pulseaudio.source_info(
                         application_input.source
                     ).mute  # system input is not muted


### PR DESCRIPTION
Hi!
With this pull request i want to fix #75

On PipeWire there are a lot more detectable sources & sinks than with PulseAudio: every time some process peaks for volume playback, that same process will be seen as a recording stream aswell.
For this reason calling `pulseaudio.get_peak_sample()` created a momentary process with `name="peak detect"` that was then destroyed when we analysed it. I thus added a check on recording sources's name to avoid checking on the "peak detector".

Note: with current implementation, `plasmashell` is seen as a recording process with PipeWire. That is because the Plasma integrates into its volume mixer a colorbar showing the application/device activity volume.
```
DEBUG:caffeine.triggers:Video playback detected (spotify, plasmashell, plasmashell, plasmashell, plasmashell, plasmashell, plasmashell, plasmashell, plasmashell).
```

In my setup I fixed this by simply blacklisting `plasmashell`, but it may be worth it hardcoding it / warn somewhere of this "feature" or removing audio recording detection all together (or moving it to a whitelist rather than a blacklist?)

Additionally: i increased the peak sampling time from `0.1` to `0.3` because otherwise, with music playing at relatively low volume, it wouldn't detect _any_ activity