### PR TITLE
chore: Update imports to work on latest Manjaro i3 x86_64

### DIFF
--- a/caffeine/applicationinstance.py
+++ b/caffeine/applicationinstance.py
@@ -20,7 +20,10 @@ import os
 from contextlib import contextmanager
 from typing import Optional
 
-from xdg.BaseDirectory import get_runtime_dir
+try:
+    from xdg.BaseDirectory import get_runtime_dir
+except ModuleNotFoundError:
+    from xdg import xdg_runtime_dir as get_runtime_dir
 
 logger = logging.getLogger(__name__)
 

--- a/caffeine/paths.py
+++ b/caffeine/paths.py
@@ -18,7 +18,11 @@ from os import makedirs
 from os.path import exists
 from os.path import join
 
-from xdg.BaseDirectory import xdg_config_home
+try:
+    from xdg.BaseDirectory import xdg_config_home
+except ModuleNotFoundError:
+    from xdg import xdg_config_home
+    xdg_config_home = str(xdg_config_home())
 
 PACKAGE_PATH = os.path.dirname(os.path.abspath(__file__))
 LOCALE_PATH = join(PACKAGE_PATH, "locale")


### PR DESCRIPTION
Kernel: 5.13.19-2-MANJARO
Packages up to date

I needed to make these edits to make caffeine-ng work on my brand new installation of Manjaro i3 with all packages up to date.

Installed caffeine through the package manager with all dependencies.