### PR TITLE
Replacing “šetřič” with “spořič” in the Czech translation

### DIFF
--- a/translations/cs.po
+++ b/translations/cs.po
@@ -160,7 +160,7 @@ msgstr ""
 
 #: caffeine/main.py:314 caffeine/main.py:400
 msgid "Disable Caffeine"
-msgstr "Povolit šetřič obrazovky"
+msgstr "Povolit spořič obrazovky"
 
 #: caffeine/core.py:156
 msgid "Timed activation set; "
@@ -228,7 +228,7 @@ msgstr "Caffeine bude zabraňovat šetření energií pro příští "
 #~ msgstr "Prosím instalujte"
 
 #~ msgid "Disable Screensaver for..."
-#~ msgstr "Vypnout šetřič obrazovky na ..."
+#~ msgstr "Vypnout spořič obrazovky na ..."
 
 #~ msgid "Autostart"
 #~ msgstr "Automatické spuštění"


### PR DESCRIPTION
“spořič obrazovky” and “šetřič obrazovky” mean the same thing, and both are used in the translation, so the translation is inconsistent. I replaced all occurrences of “šetřič obrazovky” with “spořič obrazovky” to make it consistent and because “spořič obrazovky” is used more than “šetřič obrazovky” in the translation and in general Czech communication.